### PR TITLE
Update XmlTvListingsProvider.cs

### DIFF
--- a/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
@@ -167,7 +167,7 @@ namespace Jellyfin.LiveTv.Listings
                 Overview = program.Description,
                 ProductionYear = program.CopyrightDate?.Year,
                 SeasonNumber = program.Episode.Series,
-                IsSeries = program.Episode.Series is not null,
+                IsSeries = EpisodeNumber is not null,
                 IsRepeat = program.IsPreviouslyShown && !program.IsNew,
                 IsPremiere = program.Premiere is not null,
                 IsKids = programCategories.Any(c => info.KidsCategories.Contains(c, StringComparison.OrdinalIgnoreCase)),


### PR DESCRIPTION
This fixes a bug where the record series button is not displayed on some programs like "Good Morning America" or "The View". 

Tested on Ubuntu noble.


**Changes**
If a program has an Episode number then assume it is part of a series so the record series button will display.

